### PR TITLE
Fixes display scaling in UWP

### DIFF
--- a/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
+++ b/src/skiasharp/LiveChartsCore.SkiaSharpView.UWP/MotionCanvas.xaml.cs
@@ -95,6 +95,8 @@ namespace LiveChartsCore.SkiaSharpView.UWP
 
         private void OnPaintSurface(object? sender, SKPaintSurfaceEventArgs args)
         {
+            var scaleFactor = DisplayInformation.GetForCurrentView().RawPixelsPerViewPixel;
+            args.Surface.Canvas.Scale((float)scaleFactor, (float)scaleFactor);
             CanvasCore.DrawFrame(new SkiaSharpDrawingContext(CanvasCore, args.Info, args.Surface, args.Surface.Canvas));
         }
 


### PR DESCRIPTION
When using HIDPI monitor with display scaling set to greater than 100%, chart canvas would not scale correctly. This PR corrects this issue, see before & after pics below:-

![image](https://user-images.githubusercontent.com/89976865/132247563-ae9b42db-6449-42a2-898c-422e7b87520e.png)

![scaling](https://user-images.githubusercontent.com/89976865/132247159-dcde56d5-168b-4bb8-a486-1071e4dc8849.png)
